### PR TITLE
Fix type of SRV target

### DIFF
--- a/modules/records.nix
+++ b/modules/records.nix
@@ -299,8 +299,8 @@ lib.mapAttrs
               description = lib.mdDoc ''
                 The canonical hostname of the machine providing the service.
               '';
-              example = "ftp://example.com/public";
-              type = lib.types.int;
+              example = "example.com";
+              type = with lib.types; nullOr str; # change str to lib.types.domain once it exists;
               apply = x: "${x}.";
             };
           };

--- a/modules/records.nix
+++ b/modules/records.nix
@@ -300,7 +300,7 @@ lib.mapAttrs
                 The canonical hostname of the machine providing the service.
               '';
               example = "example.com";
-              type = with lib.types; nullOr str; # change str to lib.types.domain once it exists;
+              type = lib.types.str; # change str to lib.types.domain once it exists;
               apply = x: "${x}.";
             };
           };

--- a/utils/tests/debug.nix
+++ b/utils/tests/debug.nix
@@ -46,6 +46,9 @@ in
         "example.org" = {
           cname = { data = [ "www.example.com" ]; ttl = 60; };
         };
+        "_xmpp._tcp.example.org" = {
+          srv = { data = [ { port = 5223; priority = 10; weight = 5; target = "host1.example.com."; } ]; ttl = 60; };
+        };
       };
     };
   };

--- a/utils/tests/debug.nix
+++ b/utils/tests/debug.nix
@@ -47,7 +47,7 @@ in
           cname = { data = [ "www.example.com" ]; ttl = 60; };
         };
         "_xmpp._tcp.example.org" = {
-          srv = { data = [ { port = 5223; priority = 10; weight = 5; target = "host1.example.com."; } ]; ttl = 60; };
+          srv = { data = [{ port = 5223; priority = 10; weight = 5; target = "host1.example.com."; }]; ttl = 60; };
         };
       };
     };

--- a/utils/tests/domains.nix
+++ b/utils/tests/domains.nix
@@ -129,7 +129,7 @@
           cname = { data = [ "www.example.com" ]; ttl = 60; };
         };
         "_xmpp._tcp.example.org" = {
-          srv = { data = [ { port = 5223; priority = 10; weight = 5; target = "host1.example.com."; } ]; ttl = 60; };
+          srv = { data = [{ port = 5223; priority = 10; weight = 5; target = "host1.example.com."; }]; ttl = 60; };
         };
       };
     };

--- a/utils/tests/domains.nix
+++ b/utils/tests/domains.nix
@@ -128,6 +128,9 @@
         "example.org" = {
           cname = { data = [ "www.example.com" ]; ttl = 60; };
         };
+        "_xmpp._tcp.example.org" = {
+          srv = { data = [ { port = 5223; priority = 10; weight = 5; target = "host1.example.com."; } ]; ttl = 60; };
+        };
       };
     };
   };

--- a/utils/tests/resources/dnsConfig.nix
+++ b/utils/tests/resources/dnsConfig.nix
@@ -19,6 +19,14 @@ in
         "" = {
           cname.data = "www.example.com";
         };
+        "_xmpp._tcp" = {
+          srv.data = {
+            priority = 10;
+            weight = 5;
+            port = 5223;
+            target = "host1.example.com";
+          };
+        };
       };
     };
   };


### PR DESCRIPTION
The target type of an SRV record should be a hostname, not an int.