### PR TITLE
Support Darwin systems

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
     , flake-compat
     }:
     let
-      forAllSystems = nixpkgs.lib.genAttrs [ "x86_64-linux" "aarch64-linux" ];
+      forAllSystems = nixpkgs.lib.genAttrs [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
     in
     {
       nixosModules = rec {


### PR DESCRIPTION
The direnv didn't previously support a Mac.  I am able to run all the tools in the contributing guide on an M1 with this change.