### PR TITLE
Add trailing dot to cnames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# 2024-05-06
+If you use CNAMEs a trailing dot will now be added automatically.
+This behavior is in line with other record types that use dns names.
+
+This breaks using subdomain paths in CNAMEs and if you are using full domain names
+in CNAMEs you will need to remove the trailing dot in your config.
+
+`zones."example.org"."example".cname.data = "example2"`-> `example.example.org IN CNAME example2.`
+You will now have to write it as:
+`zones."example.org"."example".cname.data = "example2.example.org"`-> `example.example.org IN CNAME example2.example.org.`

--- a/modules/records.nix
+++ b/modules/records.nix
@@ -84,7 +84,7 @@ lib.mapAttrs
             '';
             example = "foo.example.com";
             type = with lib.types; nullOr str; # change str to lib.types.domain once it exists
-            apply = x: if x != null then lib.toList x else x;
+            apply = x: if x != null then lib.toList "${x}." else x;
           };
           sub = {
             apply = lib.toList;

--- a/utils/tests/debug.nix
+++ b/utils/tests/debug.nix
@@ -98,7 +98,7 @@ in
       "example.org" = {
         "example.org" = {
           cname = {
-            data = [ "www.example.com" ];
+            data = [ "www.example.com." ];
             ttl = 60;
           };
         };

--- a/utils/tests/domains.nix
+++ b/utils/tests/domains.nix
@@ -276,7 +276,7 @@
       "example.org" = {
         "example.org" = {
           cname = {
-            data = [ "www.example.com" ];
+            data = [ "www.example.com." ];
             ttl = 60;
           };
         };


### PR DESCRIPTION
This makes the behavior consistent between NS, MX, SRV and CNAME records.

>If you use CNAMEs a trailing dot will now be added automatically.
>This behavior is in line with other record types that use dns names.
>
>This breaks using subdomain paths in CNAMEs and if you are using full domain names
>in CNAMEs you will need to remove the trailing dot in your config.
>
>`zones."example.org"."example".cname.data = "example2"`-> `example.example.org IN CNAME example2.`
>You will now have to write it as:
>`zones."example.org"."example".cname.data = "example2.example.org"`-> `example.example.org IN CNAME example2.example.org.`