### PR TITLE
replace deprecated fold function

### DIFF
--- a/utils/domains.nix
+++ b/utils/domains.nix
@@ -202,7 +202,7 @@
     let
       baseDomains =
         lib.attrNames
-          (lib.fold (l: r: lib.recursiveUpdate l r) { } (
+          (lib.foldr (l: r: lib.recursiveUpdate l r) { } (
             lib.filter (
               a:
               lib.hasAttrByPath [
@@ -228,7 +228,7 @@
         )
         subDomains
         ;
-      reducedBaseDomains = lib.fold (
+      reducedBaseDomains = lib.foldr (
         domain: acc:
         acc
         ++ (
@@ -240,7 +240,7 @@
       ) [ ] baseDomains;
       subDomainKeys = lib.attrNames subDomains;
     in
-    lib.fold (
+    lib.foldr (
       attr: acc:
       lib.recursiveUpdate acc {
         ${(utils.domains.getMostSpecific attr reducedBaseDomains)}.${attr} = subDomains.${attr};


### PR DESCRIPTION
The function `lib.fold` has been deprecated and will be removed in 26.05.

https://github.com/NixOS/nixpkgs/blob/a338f62ea8defe7b0946f9718204c29105524b35/lib/lists.nix#L152:C3