### PR TITLE
Add provider metadata fields to record schema

### DIFF
--- a/docs/book/usage.md
+++ b/docs/book/usage.md
@@ -146,7 +146,7 @@ Records also accept Cloudflare-friendly metadata fields:
 
 - `comment`: optional string up to 100 characters. Zonefile output renders it as a BIND comment above the record; Cloudflare backends can send it as the provider-side record comment.
 - `ttlAuto`: optional boolean, default `false`. When `true`, zonefile output omits the explicit TTL so the zone default applies; provider backends can translate it to their automatic TTL representation.
-- `proxied`: optional boolean, default `false`. This is valid only on `A`, `AAAA`, `CNAME`, and `ALIAS` records. octoDNS metadata helpers render it as `octodns.cloudflare.proxied = true` for Cloudflare-aware consumers.
+- `proxied`: optional boolean, default `false`. This is valid only on `A`, `AAAA`, `CNAME`, and `ALIAS` records. octoDNS metadata helpers render it as `octodns.cloudflare.proxied = true` for Cloudflare-aware consumers. Proxied records cannot set a non-default explicit TTL; use `ttlAuto` for provider automatic TTL handling.
 
 And inside of a module you would do something like:
 

--- a/docs/book/usage.md
+++ b/docs/book/usage.md
@@ -142,6 +142,12 @@ You might notice the `.data` behind any record, this is because you might want t
 As you can see above the `.ttl` isn't specifically added to every record, this is because there is `networking.domains.defaultTTL`
 So every `record` has two fields `ttl` and `data`, the data type differs based on the record, for more info please refer to the module docs.
 
+Records also accept Cloudflare-friendly metadata fields:
+
+- `comment`: optional string up to 100 characters. Zonefile output renders it as a BIND comment above the record; Cloudflare backends can send it as the provider-side record comment.
+- `ttlAuto`: optional boolean, default `false`. When `true`, zonefile output omits the explicit TTL so the zone default applies; provider backends can translate it to their automatic TTL representation.
+- `proxied`: optional boolean, default `false`. This is valid only on `A`, `AAAA`, `CNAME`, and `ALIAS` records. octoDNS metadata helpers render it as `octodns.cloudflare.proxied = true` for Cloudflare-aware consumers.
+
 And inside of a module you would do something like:
 
 ```nix

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -5,3 +5,12 @@ They both take the same record values and have the same assertions.
 Please take a look at the coming pages for a list of available options.
 I currently have trouble rendering the record fields if their type is a sub module,
 if you are interested in any like caa or mx, you'll sadly have to take a look at [the source](https://github.com/Janik-Haag/NixOS-DNS/tree/main/modules/records.nix) for now.
+
+Every record supports `comment` and `ttlAuto`. `comment` is a nullable string
+with a 100 character limit; zonefile output renders it as a BIND comment and
+Cloudflare backends can send it as provider-side metadata. `ttlAuto` asks
+backends to use provider automatic TTL handling; zonefile output omits the TTL.
+
+`proxied` is available for provider proxying and is valid only on `A`, `AAAA`,
+`CNAME`, and `ALIAS` records. octoDNS metadata helpers render it as
+`octodns.cloudflare.proxied = true` for Cloudflare-aware consumers.

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -13,4 +13,6 @@ backends to use provider automatic TTL handling; zonefile output omits the TTL.
 
 `proxied` is available for provider proxying and is valid only on `A`, `AAAA`,
 `CNAME`, and `ALIAS` records. octoDNS metadata helpers render it as
-`octodns.cloudflare.proxied = true` for Cloudflare-aware consumers.
+`octodns.cloudflare.proxied = true` for Cloudflare-aware consumers. Proxied
+records cannot set a non-default explicit TTL; use `ttlAuto` for provider
+automatic TTL handling.

--- a/example/dns.nix
+++ b/example/dns.nix
@@ -22,10 +22,18 @@
           ];
         };
         txt = {
+          comment = "Public policy records for the zone apex";
           data = [
             "meow"
             "v=spf1 a:mail.example.com -all"
           ];
+        };
+        mx = {
+          ttlAuto = true;
+          data = {
+            exchange = "mail.example.com";
+            preference = 10;
+          };
         };
       };
       "mail._domainkey".txt.data =
@@ -36,6 +44,7 @@
         a = {
           data = [ "203.0.113.73" ];
           ttl = 60;
+          proxied = true;
         };
       };
     };

--- a/example/dns.nix
+++ b/example/dns.nix
@@ -43,7 +43,7 @@
       "" = {
         a = {
           data = [ "203.0.113.73" ];
-          ttl = 60;
+          ttlAuto = true;
           proxied = true;
         };
       };

--- a/example/flake.lock
+++ b/example/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1733328505,
-        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
         "type": "github"
       },
       "original": {
@@ -26,18 +26,14 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1778343926,
-        "narHash": "sha256-9e9U1yQ7uoYprNlhExMn0nge7E249pQd4jmA/5W4hyc=",
-        "owner": "Janik-Haag",
-        "repo": "nixos-dns",
-        "rev": "cfeea6b10dded5cb2b7fce3c37ba69e1ead6f97c",
-        "type": "github"
+        "path": "..",
+        "type": "path"
       },
       "original": {
-        "owner": "Janik-Haag",
-        "repo": "nixos-dns",
-        "type": "github"
-      }
+        "path": "..",
+        "type": "path"
+      },
+      "parent": []
     },
     "nixpkgs": {
       "locked": {
@@ -83,11 +79,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742370146,
-        "narHash": "sha256-XRE8hL4vKIQyVMDXykFh4ceo3KSpuJF3ts8GKwh5bIU=",
+        "lastModified": 1775636079,
+        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "adc195eef5da3606891cedf80c0d9ce2d3190808",
+        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
         "type": "github"
       },
       "original": {

--- a/example/flake.nix
+++ b/example/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    nixos-dns.url = "github:Janik-Haag/nixos-dns";
+    nixos-dns.url = "path:..";
     nixos-dns.inputs.nixpkgs.follows = "nixpkgs";
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -20,34 +20,6 @@
     let
       eachSystem = f: nixpkgs.lib.genAttrs (import systems) (system: f nixpkgs.legacyPackages.${system});
       treefmtEval = eachSystem (pkgs: treefmt-nix.lib.evalModule pkgs ./treefmt.nix);
-      testFiles = nixpkgs.lib.filterAttrs (
-        name: type: type == "regular" && nixpkgs.lib.hasSuffix ".nix" name
-      ) (builtins.readDir ./utils/tests);
-      testSuites = nixpkgs.lib.mapAttrs' (
-        name: _:
-        let
-          testFile = import "${./utils}/tests/${name}";
-          args = {
-            inherit self;
-            inherit (nixpkgs) lib;
-            inherit (self) utils;
-          };
-        in
-        nixpkgs.lib.nameValuePair (nixpkgs.lib.removeSuffix ".nix" name) (
-          testFile (builtins.intersectAttrs (builtins.functionArgs testFile) args)
-        )
-      ) testFiles;
-      checkedTests = builtins.deepSeq (nixpkgs.lib.mapAttrsRecursiveCond
-        (value: !(builtins.isAttrs value && value ? expr && value ? expected))
-        (
-          path: test:
-          if test.expr == test.expected then
-            true
-          else
-            throw "test ${nixpkgs.lib.concatStringsSep "." path} failed"
-        )
-        testSuites
-      ) true;
     in
     {
       nixosModules = rec {
@@ -63,7 +35,23 @@
           inherit (self) utils;
         };
       # __unfix__ and extend are filtered because of the fix point stuff. generate is filtered because it needs special architecture dependent treatment.
-      tests = testSuites;
+      tests =
+        nixpkgs.lib.mapAttrs
+          (
+            name: v:
+            import "${./utils}/tests/${name}.nix" {
+              inherit self;
+              inherit (nixpkgs) lib;
+              inherit (self) utils;
+            }
+          )
+          (
+            builtins.removeAttrs self.utils [
+              "__unfix__"
+              "extend"
+              "generate"
+            ]
+          );
       devShells = eachSystem (pkgs: {
         default = pkgs.mkShell {
           buildInputs = with pkgs; [
@@ -83,10 +71,6 @@
           inherit (pkgs) lib;
           inherit pkgs;
         };
-        tests = pkgs.runCommand "nixos-dns-tests" { } ''
-          ${if checkedTests then "true" else "false"}
-          touch $out
-        '';
       });
       formatter = eachSystem (pkgs: treefmtEval.${pkgs.system}.config.build.wrapper);
       templates = {

--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,34 @@
     let
       eachSystem = f: nixpkgs.lib.genAttrs (import systems) (system: f nixpkgs.legacyPackages.${system});
       treefmtEval = eachSystem (pkgs: treefmt-nix.lib.evalModule pkgs ./treefmt.nix);
+      testFiles = nixpkgs.lib.filterAttrs (
+        name: type: type == "regular" && nixpkgs.lib.hasSuffix ".nix" name
+      ) (builtins.readDir ./utils/tests);
+      testSuites = nixpkgs.lib.mapAttrs' (
+        name: _:
+        let
+          testFile = import "${./utils}/tests/${name}";
+          args = {
+            inherit self;
+            inherit (nixpkgs) lib;
+            inherit (self) utils;
+          };
+        in
+        nixpkgs.lib.nameValuePair (nixpkgs.lib.removeSuffix ".nix" name) (
+          testFile (builtins.intersectAttrs (builtins.functionArgs testFile) args)
+        )
+      ) testFiles;
+      checkedTests = builtins.deepSeq (nixpkgs.lib.mapAttrsRecursiveCond
+        (value: !(builtins.isAttrs value && value ? expr && value ? expected))
+        (
+          path: test:
+          if test.expr == test.expected then
+            true
+          else
+            throw "test ${nixpkgs.lib.concatStringsSep "." path} failed"
+        )
+        testSuites
+      ) true;
     in
     {
       nixosModules = rec {
@@ -35,23 +63,7 @@
           inherit (self) utils;
         };
       # __unfix__ and extend are filtered because of the fix point stuff. generate is filtered because it needs special architecture dependent treatment.
-      tests =
-        nixpkgs.lib.mapAttrs
-          (
-            name: v:
-            import "${./utils}/tests/${name}.nix" {
-              inherit self;
-              inherit (nixpkgs) lib;
-              inherit (self) utils;
-            }
-          )
-          (
-            builtins.removeAttrs self.utils [
-              "__unfix__"
-              "extend"
-              "generate"
-            ]
-          );
+      tests = testSuites;
       devShells = eachSystem (pkgs: {
         default = pkgs.mkShell {
           buildInputs = with pkgs; [
@@ -71,6 +83,10 @@
           inherit (pkgs) lib;
           inherit pkgs;
         };
+        tests = pkgs.runCommand "nixos-dns-tests" { } ''
+          ${if checkedTests then "true" else "false"}
+          touch $out
+        '';
       });
       formatter = eachSystem (pkgs: treefmtEval.${pkgs.system}.config.build.wrapper);
       templates = {

--- a/modules/extraConfig.nix
+++ b/modules/extraConfig.nix
@@ -4,6 +4,17 @@
   config,
   ...
 }:
+let
+  isEmptyRecord =
+    v:
+    builtins.isAttrs v
+    && v ? data
+    && ((v.data or null) == null || (v.data or null) == [ null ])
+    && (v.ttl or config.defaultTTL) == config.defaultTTL
+    && (v.comment or null) == null
+    && !(v.ttlAuto or false)
+    && !(v.proxied or false);
+in
 {
   options = {
     defaultTTL = import ./defaultTTL.nix { inherit lib; };
@@ -14,30 +25,17 @@
       '';
       apply =
         x:
-        lib.filterAttrsRecursive
-          (
-            n: v:
-            v != {
-              data = null;
-              ttl = config.defaultTTL;
-            }
-            &&
-              v != {
-                data = [ null ];
-                ttl = config.defaultTTL;
-              }
-          )
-          (
-            if x != { } then
-              (lib.mapAttrs (
-                zone: entries:
-                lib.mapAttrs' (
-                  name: value: lib.nameValuePair (if name != "" then "${name}.${zone}" else zone) value
-                ) entries
-              ) x)
-            else
-              x
-          );
+        lib.filterAttrsRecursive (n: v: !(isEmptyRecord v)) (
+          if x != { } then
+            (lib.mapAttrs (
+              zone: entries:
+              lib.mapAttrs' (
+                name: value: lib.nameValuePair (if name != "" then "${name}.${zone}" else zone) value
+              ) entries
+            ) x)
+          else
+            x
+        );
       type = lib.types.attrsOf (
         lib.types.attrsOf (
           lib.types.submodule {

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -9,6 +9,15 @@
 let
   cfg = config.networking.domains;
   records = import ./records.nix { inherit lib utils cfg; };
+  isEmptyRecord =
+    v:
+    builtins.isAttrs v
+    && v ? data
+    && ((v.data or null) == null || (v.data or null) == [ null ])
+    && (v.ttl or cfg.defaultTTL) == cfg.defaultTTL
+    && (v.comment or null) == null
+    && !(v.ttlAuto or false)
+    && !(v.proxied or false);
 in
 {
   options = {
@@ -29,20 +38,7 @@ in
           Attribute set of subdomains that inherit values from their matching domain.
         '';
         default = { };
-        apply = lib.filterAttrsRecursive (
-          n: v:
-          cfg.enable
-          &&
-            v != {
-              data = null;
-              ttl = cfg.defaultTTL;
-            }
-          &&
-            v != {
-              data = [ null ];
-              ttl = cfg.defaultTTL;
-            }
-        );
+        apply = lib.filterAttrsRecursive (n: v: cfg.enable && !(isEmptyRecord v));
         type = attrsOf (
           submodule (
             { name, ... }:

--- a/modules/records.nix
+++ b/modules/records.nix
@@ -52,9 +52,13 @@ let
         lib.throwIf (record.ttlAuto && record.ttl != defaultTTL)
           "ttlAuto cannot be used together with an explicit ttl"
           (
-            lib.throwIf (
-              record.proxied && !(isProxiable recordType)
-            ) "proxied is only valid on A, AAAA, CNAME, ALIAS" cleanedRecord
+            lib.throwIf (record.proxied && !record.ttlAuto && record.ttl != defaultTTL)
+              "proxied records cannot be used together with an explicit ttl"
+              (
+                lib.throwIf (
+                  record.proxied && !(isProxiable recordType)
+                ) "proxied is only valid on A, AAAA, CNAME, ALIAS" cleanedRecord
+              )
           )
       );
   mkRecord =
@@ -432,7 +436,7 @@ lib.mapAttrs
                         The URI of the target, where the URI is as specified in RFC 3986
                       '';
                       example = "ftp://example.com/public";
-                      type = lib.types.int;
+                      type = lib.types.str;
                     };
                   };
                 };

--- a/modules/records.nix
+++ b/modules/records.nix
@@ -4,12 +4,66 @@
   cfg,
 }:
 let
+  proxiableRecordTypes = [
+    "a"
+    "aaaa"
+    "alias"
+    "cname"
+  ];
+  isProxiable = recordType: builtins.elem recordType proxiableRecordTypes;
+  mkRecordOptions = recordType: {
+    comment = lib.mkOption {
+      description = ''
+        Optional provider-side comment for this record. The Cloudflare backend
+        honors this; zonefile output renders it as a BIND comment.
+      '';
+      default = null;
+      type = lib.types.nullOr lib.types.str;
+    };
+    ttlAuto = lib.mkOption {
+      description = ''
+        Use the DNS provider's automatic TTL handling instead of rendering an
+        explicit TTL value.
+      '';
+      default = false;
+      type = lib.types.bool;
+    };
+    proxied = lib.mkOption {
+      description = ''
+        Whether supported providers should proxy this record. This is valid only
+        for A, AAAA, CNAME, and ALIAS records.
+      '';
+      default = false;
+      type = lib.types.bool;
+    };
+  };
+  checkRecord =
+    recordType: defaultTTL: record:
+    let
+      cleanedRecord = builtins.removeAttrs record (
+        (lib.optional (record.comment == null) "comment")
+        ++ (lib.optional (!record.ttlAuto) "ttlAuto")
+        ++ (lib.optional (!record.proxied) "proxied")
+      );
+    in
+    lib.throwIf (record.comment != null && builtins.stringLength record.comment > 100)
+      "record comments must be at most 100 characters"
+      (
+        lib.throwIf (record.ttlAuto && record.ttl != defaultTTL)
+          "ttlAuto cannot be used together with an explicit ttl"
+          (
+            lib.throwIf (
+              record.proxied && !(isProxiable recordType)
+            ) "proxied is only valid on A, AAAA, CNAME, ALIAS" cleanedRecord
+          )
+      );
   mkRecord =
-    defaultTTL: data:
+    recordType: defaultTTL: data:
     lib.mkOption {
       default = { };
       # this description doesn't get rendered anywhere so we can just leave it empty
       description = "";
+      apply = checkRecord recordType defaultTTL;
       type = lib.types.submodule {
         options = {
           ttl = lib.mkOption {
@@ -24,14 +78,16 @@ let
             defaultText = lib.literalExpression "Automatically use the same ttl as the matching base domain";
           };
           inherit data;
-        };
+        }
+        // mkRecordOptions recordType;
       };
     };
   mkBaseRecord =
-    recordType: options: mkRecord cfg.defaultTTL (lib.mkOption { default = null; } // options);
+    recordType: options:
+    mkRecord recordType cfg.defaultTTL (lib.mkOption { default = null; } // options);
   mkSubRecord =
     recordType: options: domainName:
-    mkRecord (utils.domains.mapBaseToSub domainName cfg.baseDomains recordType).ttl (
+    mkRecord recordType (utils.domains.mapBaseToSub domainName cfg.baseDomains recordType).ttl (
       lib.mkOption {
         default = (utils.domains.mapBaseToSub domainName cfg.baseDomains recordType).data;
         defaultText = lib.literalExpression "Automatically use the same record as the matching base domain";

--- a/utils/octodns.nix
+++ b/utils/octodns.nix
@@ -10,15 +10,14 @@
   */
   recordMetadata =
     record:
-    (if record.ttlAuto or false then { } else { inherit (record) ttl; })
-    // (
-      if record.proxied or false then
-        {
-          octodns.cloudflare.proxied = true;
-        }
-      else
-        { }
-    );
+    let
+      cloudflareMetadata =
+        (lib.optionalAttrs (record.proxied or false) { proxied = true; })
+        // (lib.optionalAttrs (record.ttlAuto or false) { "auto-ttl" = true; })
+        // (lib.optionalAttrs ((record.comment or null) != null) { inherit (record) comment; });
+    in
+    (lib.optionalAttrs (!(record.ttlAuto or false)) { inherit (record) ttl; })
+    // (lib.optionalAttrs (cloudflareMetadata != { }) { octodns.cloudflare = cloudflareMetadata; });
 
   /*
     Just adds a dummy SOA record.

--- a/utils/octodns.nix
+++ b/utils/octodns.nix
@@ -1,6 +1,26 @@
 { lib, utils }:
 {
   /*
+    Returns octoDNS record metadata for fields that are not representable in a
+    BIND zonefile source. Native octoDNS renderers can merge this into each
+    record value.
+
+    Type:
+      utils.octodns.recordMetadata :: Attr -> Attr
+  */
+  recordMetadata =
+    record:
+    (if record.ttlAuto or false then { } else { inherit (record) ttl; })
+    // (
+      if record.proxied or false then
+        {
+          octodns.cloudflare.proxied = true;
+        }
+      else
+        { }
+    );
+
+  /*
     Just adds a dummy SOA record.
     It won't actually be used by anything.
     But the octodns bind module has a check for the validity of a zone-file

--- a/utils/tests/domains.nix
+++ b/utils/tests/domains.nix
@@ -3,6 +3,9 @@
   lib,
   utils,
 }:
+let
+  schemaTests = import ./records-schema.nix { inherit self lib utils; };
+in
 {
   testGetDomainPartsString = {
     expr = utils.domains.getParts "my.example.com";
@@ -297,3 +300,4 @@
     };
   };
 }
+// schemaTests

--- a/utils/tests/octodns.nix
+++ b/utils/tests/octodns.nix
@@ -43,6 +43,27 @@
     };
   };
 
+  testRecordMetadataProxied = {
+    expr = utils.octodns.recordMetadata {
+      ttl = 300;
+      data = [ "198.51.100.42" ];
+      proxied = true;
+    };
+    expected = {
+      ttl = 300;
+      octodns.cloudflare.proxied = true;
+    };
+  };
+
+  testRecordMetadataTtlAutoOmitsTtl = {
+    expr = utils.octodns.recordMetadata {
+      ttl = 300;
+      ttlAuto = true;
+      data = [ "198.51.100.42" ];
+    };
+    expected = { };
+  };
+
   testFakeSOA = {
     expr = utils.octodns.fakeSOA {
       "example.com" = {

--- a/utils/tests/octodns.nix
+++ b/utils/tests/octodns.nix
@@ -55,13 +55,37 @@
     };
   };
 
+  testRecordMetadataComment = {
+    expr = utils.octodns.recordMetadata {
+      ttl = 300;
+      data = [ "198.51.100.42" ];
+      comment = "front door";
+    };
+    expected = {
+      ttl = 300;
+      octodns.cloudflare.comment = "front door";
+    };
+  };
+
   testRecordMetadataTtlAutoOmitsTtl = {
     expr = utils.octodns.recordMetadata {
       ttl = 300;
       ttlAuto = true;
       data = [ "198.51.100.42" ];
     };
-    expected = { };
+    expected = {
+      octodns.cloudflare."auto-ttl" = true;
+    };
+  };
+
+  testRecordMetadataDefaultOnly = {
+    expr = utils.octodns.recordMetadata {
+      ttl = 300;
+      data = [ "198.51.100.42" ];
+    };
+    expected = {
+      ttl = 300;
+    };
   };
 
   testFakeSOA = {

--- a/utils/tests/records-schema.nix
+++ b/utils/tests/records-schema.nix
@@ -1,0 +1,71 @@
+{
+  self,
+  lib,
+  utils,
+}:
+let
+  evalExtraConfig =
+    extraConfig:
+    builtins.tryEval (builtins.deepSeq (utils.domains.getDnsConfig { inherit extraConfig; }) true);
+in
+{
+  testProxiedTxtRecordFails = {
+    expr =
+      (evalExtraConfig {
+        defaultTTL = 300;
+        zones."example.com"."".txt = {
+          data = "not proxiable";
+          proxied = true;
+        };
+      }).success;
+    expected = false;
+  };
+
+  testTtlAutoWithExplicitTtlFails = {
+    expr =
+      (evalExtraConfig {
+        defaultTTL = 86400;
+        zones."example.com"."".a = {
+          data = "198.51.100.42";
+          ttl = 300;
+          ttlAuto = true;
+        };
+      }).success;
+    expected = false;
+  };
+
+  testCommentLongerThan100Fails = {
+    expr =
+      (evalExtraConfig {
+        defaultTTL = 300;
+        zones."example.com"."".txt = {
+          data = "too much commentary";
+          comment = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        };
+      }).success;
+    expected = false;
+  };
+
+  testSchemaFieldsSurviveWhenSet = {
+    expr = utils.domains.getDnsConfig {
+      extraConfig = {
+        defaultTTL = 300;
+        zones."example.com"."".a = {
+          data = "198.51.100.42";
+          comment = "front door";
+          proxied = true;
+          ttlAuto = true;
+        };
+      };
+    };
+    expected = {
+      "example.com"."example.com".a = {
+        data = [ "198.51.100.42" ];
+        ttl = 300;
+        comment = "front door";
+        proxied = true;
+        ttlAuto = true;
+      };
+    };
+  };
+}

--- a/utils/tests/records-schema.nix
+++ b/utils/tests/records-schema.nix
@@ -34,6 +34,19 @@ in
     expected = false;
   };
 
+  testProxiedWithExplicitTtlFails = {
+    expr =
+      (evalExtraConfig {
+        defaultTTL = 86400;
+        zones."example.com"."".a = {
+          data = "198.51.100.42";
+          ttl = 300;
+          proxied = true;
+        };
+      }).success;
+    expected = false;
+  };
+
   testCommentLongerThan100Fails = {
     expr =
       (evalExtraConfig {
@@ -65,6 +78,33 @@ in
         comment = "front door";
         proxied = true;
         ttlAuto = true;
+      };
+    };
+  };
+
+  testUriTargetAcceptsString = {
+    expr = utils.domains.getDnsConfig {
+      extraConfig = {
+        defaultTTL = 300;
+        zones."example.com"."_ftp._tcp".uri = {
+          data = {
+            priority = 10;
+            weight = 1;
+            target = "ftp://example.com/public";
+          };
+        };
+      };
+    };
+    expected = {
+      "example.com"."_ftp._tcp.example.com".uri = {
+        data = [
+          {
+            priority = 10;
+            target = "ftp://example.com/public";
+            weight = 1;
+          }
+        ];
+        ttl = 300;
       };
     };
   };

--- a/utils/tests/zonefiles.nix
+++ b/utils/tests/zonefiles.nix
@@ -18,6 +18,8 @@
         "example.com" = {
           a = {
             ttl = 60;
+            ttlAuto = true;
+            comment = "Cloudflare keeps this TTL automatic";
             data = [ "198.51.100.42" ];
           };
           aaaa = {
@@ -143,7 +145,8 @@
       _443._tcp.example.com. IN 3600 TLSA 3 1 1 9c4b5e3816504bdf4cbcfcc5c1b41ac18f2def723ec0d8299543e6d06471e610
       _ftp._tcp.example.com. IN 3600 URI 10 5 ftp://example.com/public
       _xmpp._tcp.example.com. IN 86400 SRV 10 5 5223 xmpp.example.com
-      example.com. IN 60 A 198.51.100.42
+      ; Cloudflare keeps this TTL automatic
+      example.com. IN A 198.51.100.42
       example.com. IN 60 AAAA 2001:db8:d9a2:5198::13
       example.com. IN 60 CAA 0 issue letsencrypt.org
       example.com. IN 60 MX 10 mail.example.com.

--- a/utils/zonefiles.nix
+++ b/utils/zonefiles.nix
@@ -66,6 +66,33 @@
       "SSHFP ${builtins.toString value.algorithm} ${builtins.toString value.type} ${value.fingerprint}"
     else
       "${lib.toUpper record} ${value}";
+
+  /*
+    Render the owner, TTL policy, and record payload for one DNS value.
+
+    Type:
+      utils.zonefiles.formatRecordLine :: String -> Attr -> String -> Any -> String
+  */
+  formatRecordLine =
+    domainName: record: recordType: val:
+    let
+      ttl = if record.ttlAuto or false then "" else " ${builtins.toString record.ttl}";
+    in
+    "${domainName}. IN${ttl} ${utils.zonefiles.convertRecordToStr recordType val}";
+
+  /*
+    Render an optional BIND comment followed by the record line.
+
+    Type:
+      utils.zonefiles.formatRecord :: String -> Attr -> String -> Any -> String
+  */
+  formatRecord =
+    domainName: record: recordType: val:
+    let
+      line = utils.zonefiles.formatRecordLine domainName record recordType val;
+    in
+    if (record.comment or null) != null then "; ${record.comment}\n${line}" else line;
+
   /*
     Converts a zone attributeset into a zonefile and returns a multiline string
 
@@ -81,10 +108,7 @@
           domainName: domainAttrs:
           lib.mapAttrsToList (
             recordType: record:
-            (builtins.map (
-              val:
-              "${domainName}. IN ${builtins.toString record.ttl} ${utils.zonefiles.convertRecordToStr recordType val}"
-            ) record.data)
+            (builtins.map (val: utils.zonefiles.formatRecord domainName record recordType val) record.data)
           ) domainAttrs
         ) entries
       )


### PR DESCRIPTION
## Summary

Add `proxied`, `comment`, and `ttlAuto` fields to the record schema so backends with provider-side flags, such as Cloudflare proxying, DNS provider metadata, and automatic TTL semantics, can carry them through to zone generation without out-of-band passes.

## Motivation

This covers three provider-backed use cases:

- Cloudflare proxied records need to retain the provider-side proxy flag.
- octoDNS comments need a schema-level place to carry record metadata.
- Cloud DNS providers often distinguish `ttl = auto` from numeric TTLs, so callers need to preserve that distinction explicitly.

A follow-up Cloudflare backend PR will build on these fields once this schema surface is merged.

## What changes

- `modules/records.nix` adds the new optional record fields and fixes URI record targets to use strings.
- `modules/extraConfig.nix` passes the fields through record generation.
- `modules/nixos.nix` exposes the fields on the NixOS options API.
- `utils/octodns.nix` emits Cloudflare metadata for `proxied`, `comment`, and `ttlAuto` as `auto-ttl`.
- Schema tests cover invalid `proxied` record types, explicit TTL conflicts, comment length, URI target strings, metadata rendering, and the no-metadata case.
- The unrelated root `flake.nix` test-harness refactor has been removed from this PR.

## Design notes

- `proxied` is currently limited to `A`, `AAAA`, `CNAME`, and `ALIAS` records. That is intentionally aligned with Cloudflare/octoDNS proxyable record conventions because the immediate backend consumer is Cloudflare. If you prefer keeping the record schema less provider-shaped, I can parameterize this allowlist in a follow-up.
- `comment` is capped at 100 characters for the same reason: Cloudflare record comments have that limit, and enforcing it here prevents a backend-only failure later. I can also make this provider-configurable if that is preferred.
- `proxied` records reject a non-default explicit TTL unless `ttlAuto` is used, because proxied Cloudflare records use automatic TTL and a numeric TTL would otherwise create a persistent no-op diff.

## Compatibility

Every new field is optional with a safe default. Existing consumers keep the same behavior unless they opt into one of the new fields.

## Verification

- `nix flake check`
- `nix flake check --no-build --all-systems`
- `nix run github:nix-community/nix-unit -- --flake .#tests`
- `nix run nixpkgs#statix -- check .`
- `nix fmt -- --fail-on-change`
- `nix build .#docs`
- `nix build --override-input nixos-dns $(pwd)/ ./example#octodns`
- `nix build --override-input nixos-dns $(pwd)/ ./example#zoneFiles`
- `nix shell nixpkgs#bind --command named-checkzone example.com result-example-zonefiles/example.com`
