### PR TITLE
Add flake checks output

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,17 @@
     let
       eachSystem = f: nixpkgs.lib.genAttrs (import systems) (system: f nixpkgs.legacyPackages.${system});
       treefmtEval = eachSystem (pkgs: treefmt-nix.lib.evalModule pkgs ./treefmt.nix);
+      checkedTests = builtins.deepSeq (nixpkgs.lib.mapAttrsRecursiveCond
+        (value: !(builtins.isAttrs value && value ? expr && value ? expected))
+        (
+          path: test:
+          if test.expr == test.expected then
+            true
+          else
+            throw "test ${nixpkgs.lib.concatStringsSep "." path} failed"
+        )
+        self.tests
+      ) true;
     in
     {
       nixosModules = rec {
@@ -71,6 +82,17 @@
           inherit (pkgs) lib;
           inherit pkgs;
         };
+      });
+      checks = eachSystem (pkgs: {
+        tests = pkgs.runCommand "nixos-dns-tests" { } ''
+          ${if checkedTests then "true" else "false"}
+          touch $out
+        '';
+        treefmt = treefmtEval.${pkgs.system}.config.build.check self;
+        statix = pkgs.runCommand "nixos-dns-statix" { nativeBuildInputs = [ pkgs.statix ]; } ''
+          statix check ${self}
+          touch $out
+        '';
       });
       formatter = eachSystem (pkgs: treefmtEval.${pkgs.system}.config.build.wrapper);
       templates = {


### PR DESCRIPTION
## Summary

- add `checks.<system>` for the existing Nix assertion tests
- expose treefmt and statix through flake checks
- keep the GitHub Actions workflow unchanged so the existing explicit CI gates remain visible and retain `--no-build --all-systems` evaluation coverage

This adds no new flake inputs and keeps the existing explicit `self.utils`-based test list.

## Verification

- `nix flake check --no-build --all-systems`
- `nix build .#checks.x86_64-linux.tests`
- temporarily broke `utils/tests/general.nix` and confirmed `nix flake check` fails with `test general.testFillList failed`
- confirmed the `flake.nix` inputs diff is empty

## Notes

`nix fmt -- --fail-on-change` passes in the primary checkout. It fails in the linked worktree used to patch this PR because `treefmt.nix` sets `projectRootFile = ".git/config"`, and linked git worktrees have `.git` as a pointer file rather than a directory containing `config`.
